### PR TITLE
feat: Enable Github Action Installation Cache

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -9,6 +9,13 @@ jobs:
                 runs-on: ubuntu-latest
                 steps:
                         - uses: actions/checkout@v2
+                        - name: Cache dependencies
+                          uses: actions/cache@v2
+                          with:
+                                path: ~/.m2/repository
+                                key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+                                restore-keys: |
+                                        ${{ runner.os }}-maven-
                         - name: Set up Java8
                           uses: actions/setup-java@v2
                           with:
@@ -17,14 +24,6 @@ jobs:
                          
                         - name: Install dependencies
                           run: mvn clean install
-
-                        - name: Cache dependencies
-                          uses: actions/cache@v2
-                          with:
-                                path: ~/.m2/repository
-                                key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-                                restore-keys: |
-                                        ${{ runner.os }}-maven-
 
                         - name: Build docker image
                           run: mvn package docker:build -DskipTests=true


### PR DESCRIPTION
踩了一个坑。Github Action 的 Cache 要在 install dependencies 之前使用，反直觉啊。