### PR TITLE
feat: 加载数据库失败时，至少报个错提示用户

### DIFF
--- a/src/main/java/asia/asoulcnki/api/common/duplicationcheck/ComparisonDatabase.java
+++ b/src/main/java/asia/asoulcnki/api/common/duplicationcheck/ComparisonDatabase.java
@@ -58,6 +58,8 @@ public class ComparisonDatabase {
 						instance = loadFromImage(DEFAULT_DATA_DIR + "/" + DEFAULT_IMAGE_FILE_NAME);
 						log.info("load database cost {} ms", System.currentTimeMillis() - start);
 					} catch (Exception e) {
+						log.error(e.getMessage(), e);
+						log.warn("loading comparison database failed, use empty database.");
 						instance = new ComparisonDatabase();
 					}
 					instance.rwLock = new ReentrantReadWriteLock();


### PR DESCRIPTION
当用户加载数据库失败时，使用空数据库，用户此时使用任何api都是没数据的，无法及时感知错误，增加了排查成本，所以至少需要提示一下用户，报个错

另外鼠鼠感觉使用空数据库是没有意义的。如果在第一次运行时就自动训练，如果不存在 json 就报错提示用户下载json，会不会增加易用性捏