### PR TITLE
feat: 升级 fastjson 版本

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <dependency>
             <artifactId>fastjson</artifactId>
             <groupId>com.alibaba</groupId>
-            <version>1.2.41</version>
+            <version>1.2.76</version>
         </dependency>
 
         <!-- 处理配置 -->


### PR DESCRIPTION
1.2.41 是很老的版本了，有安全漏洞，建议修复
另外 fastjson 很容易曝出新的安全问题，最好能全部替换成 jackson 捏