### PR TITLE
feat: 初版随机小作文

### DIFF
--- a/src/main/java/asia/asoulcnki/api/common/duplicationcheck/LeaderBoard.java
+++ b/src/main/java/asia/asoulcnki/api/common/duplicationcheck/LeaderBoard.java
@@ -1,204 +1,220 @@
 package asia.asoulcnki.api.common.duplicationcheck;
 
+import asia.asoulcnki.api.common.util.RandomUtil;
+import asia.asoulcnki.api.enums.ASoulRoleEnum;
 import asia.asoulcnki.api.persistence.entity.Reply;
+import asia.asoulcnki.api.persistence.param.QueryRandomLoveLetterParam;
 import asia.asoulcnki.api.persistence.vo.RankingResultVo;
 import asia.asoulcnki.api.service.IRankingService.TimeRangeEnum;
+import org.apache.commons.lang3.RandomUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Calendar;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.List;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class LeaderBoard {
 
-	private final static Logger log = LoggerFactory.getLogger(LeaderBoard.class);
+    private final static Logger log = LoggerFactory.getLogger(LeaderBoard.class);
 
-	private static LeaderBoard instance;
-	// 累积赞数排序，至少为50，且引用次数至少为1
-	private final LeaderBoardEntry similarLikeSumLeaderboard;
-	// 单评论赞数排序，至少为50
-	private final LeaderBoardEntry likeLeaderBoard;
-	// 引用次数排序，至少为5
-	private final LeaderBoardEntry similarCountLeaderBoard;
+    private static LeaderBoard instance;
+    // 累积赞数排序，至少为50，且引用次数至少为1
+    private final LeaderBoardEntry similarLikeSumLeaderboard;
+    // 单评论赞数排序，至少为50
+    private final LeaderBoardEntry likeLeaderBoard;
+    // 引用次数排序，至少为5
+    private final LeaderBoardEntry similarCountLeaderBoard;
 
-	private LeaderBoard() {
+    private LeaderBoard() {
 
-		similarLikeSumLeaderboard = new LeaderBoardEntry(Comparator.comparing(Reply::getSimilarLikeSum).reversed());
-		similarLikeSumLeaderboard.setAllRepliesFilter(CommonFilterRules.similarLikeSumGreaterThan(50).and(CommonFilterRules.similarLikeCountGreaterThan(1)));
-		similarLikeSumLeaderboard.setRepliesInOneWeekFilter(CommonFilterRules.similarLikeSumGreaterThan(30).and(CommonFilterRules.similarLikeCountGreaterThan(0)));
-		similarLikeSumLeaderboard.setRepliesInThreeDaysFilter(CommonFilterRules.similarLikeSumGreaterThan(10).and(CommonFilterRules.similarLikeCountGreaterThan(0)));
+        similarLikeSumLeaderboard = new LeaderBoardEntry(Comparator.comparing(Reply::getSimilarLikeSum).reversed());
+        similarLikeSumLeaderboard.setAllRepliesFilter(CommonFilterRules.similarLikeSumGreaterThan(50).and(CommonFilterRules.similarLikeCountGreaterThan(1)));
+        similarLikeSumLeaderboard.setRepliesInOneWeekFilter(CommonFilterRules.similarLikeSumGreaterThan(30).and(CommonFilterRules.similarLikeCountGreaterThan(0)));
+        similarLikeSumLeaderboard.setRepliesInThreeDaysFilter(CommonFilterRules.similarLikeSumGreaterThan(10).and(CommonFilterRules.similarLikeCountGreaterThan(0)));
 
-		likeLeaderBoard = new LeaderBoardEntry(Comparator.comparing(Reply::getLikeNum).reversed());
-		likeLeaderBoard.setAllRepliesFilter(CommonFilterRules.likeNumGreaterThan(100));
-		likeLeaderBoard.setRepliesInOneWeekFilter(CommonFilterRules.likeNumGreaterThan(80));
-		likeLeaderBoard.setRepliesInThreeDaysFilter(CommonFilterRules.likeNumGreaterThan(50));
+        likeLeaderBoard = new LeaderBoardEntry(Comparator.comparing(Reply::getLikeNum).reversed());
+        likeLeaderBoard.setAllRepliesFilter(CommonFilterRules.likeNumGreaterThan(100));
+        likeLeaderBoard.setRepliesInOneWeekFilter(CommonFilterRules.likeNumGreaterThan(80));
+        likeLeaderBoard.setRepliesInThreeDaysFilter(CommonFilterRules.likeNumGreaterThan(50));
 
-		similarCountLeaderBoard = new LeaderBoardEntry(Comparator.comparing(Reply::getSimilarCount).reversed());
-		similarCountLeaderBoard.setAllRepliesFilter(CommonFilterRules.similarLikeCountGreaterThan(5));
-		similarCountLeaderBoard.setRepliesInOneWeekFilter(CommonFilterRules.similarLikeCountGreaterThan(1));
-		similarCountLeaderBoard.setRepliesInThreeDaysFilter(CommonFilterRules.similarLikeCountGreaterThan(0));
+        similarCountLeaderBoard = new LeaderBoardEntry(Comparator.comparing(Reply::getSimilarCount).reversed());
+        similarCountLeaderBoard.setAllRepliesFilter(CommonFilterRules.similarLikeCountGreaterThan(5));
+        similarCountLeaderBoard.setRepliesInOneWeekFilter(CommonFilterRules.similarLikeCountGreaterThan(1));
+        similarCountLeaderBoard.setRepliesInThreeDaysFilter(CommonFilterRules.similarLikeCountGreaterThan(0));
 
-		refresh();
-	}
+        refresh();
+    }
 
-	public static synchronized LeaderBoard getInstance() {
-		if (instance == null) {
-			synchronized (LeaderBoard.class) {
-				if (instance == null) {
-					instance = new LeaderBoard();
-				}
-			}
-		}
-		return instance;
-	}
+    public static synchronized LeaderBoard getInstance() {
+        if (instance == null) {
+            synchronized (LeaderBoard.class) {
+                if (instance == null) {
+                    instance = new LeaderBoard();
+                }
+            }
+        }
+        return instance;
+    }
 
-	public static <T> List<T> page(List<T> list, Integer pageSize, Integer pageNum) {
-		// now we only support page size as 10
-		if (list == null || list.isEmpty() || pageSize != 10) {
-			return null;
-		}
+    public static <T> List<T> page(List<T> list, Integer pageSize, Integer pageNum) {
+        // now we only support page size as 10
+        if (list == null || list.isEmpty() || pageSize != 10) {
+            return null;
+        }
 
-		int recordCount = list.size();
-		int pageCount = recordCount % pageSize == 0 ? recordCount / pageSize : recordCount / pageSize + 1;
+        int recordCount = list.size();
+        int pageCount = recordCount % pageSize == 0 ? recordCount / pageSize : recordCount / pageSize + 1;
 
-		int fromIndex; //开始索引
-		int toIndex; //结束索引
+        int fromIndex; //开始索引
+        int toIndex; //结束索引
 
-		if (pageNum > pageCount) {
-			pageNum = pageCount;
-		}
+        if (pageNum > pageCount) {
+            pageNum = pageCount;
+        }
 
-		if (!pageNum.equals(pageCount)) {
-			fromIndex = (pageNum - 1) * pageSize;
-			toIndex = fromIndex + pageSize;
-		} else {
-			fromIndex = (pageNum - 1) * pageSize;
-			toIndex = recordCount;
-		}
+        if (!pageNum.equals(pageCount)) {
+            fromIndex = (pageNum - 1) * pageSize;
+            toIndex = fromIndex + pageSize;
+        } else {
+            fromIndex = (pageNum - 1) * pageSize;
+            toIndex = recordCount;
+        }
 
-		return list.subList(fromIndex, toIndex);
-	}
+        return list.subList(fromIndex, toIndex);
+    }
 
-	public static void main(String[] args) {
-		Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT+8"));
-		calendar.set(Calendar.HOUR_OF_DAY, 0);
-		calendar.set(Calendar.MINUTE, 0);
-		calendar.set(Calendar.SECOND, 0);
-		long result = calendar.getTimeInMillis();
-		System.out.println(result / 1000);
-	}
+    public static void main(String[] args) {
+        Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("GMT+8"));
+        calendar.set(Calendar.HOUR_OF_DAY, 0);
+        calendar.set(Calendar.MINUTE, 0);
+        calendar.set(Calendar.SECOND, 0);
+        long result = calendar.getTimeInMillis();
+        System.out.println(result / 1000);
+    }
 
-	public LeaderBoardEntry getSimilarLikeSumLeaderboard() {
-		return similarLikeSumLeaderboard;
-	}
+    public LeaderBoardEntry getSimilarLikeSumLeaderboard() {
+        return similarLikeSumLeaderboard;
+    }
 
-	public LeaderBoardEntry getLikeLeaderBoard() {
-		return likeLeaderBoard;
-	}
+    public LeaderBoardEntry getLikeLeaderBoard() {
+        return likeLeaderBoard;
+    }
 
-	public LeaderBoardEntry getSimilarCountLeaderBoard() {
-		return similarCountLeaderBoard;
-	}
+    public LeaderBoardEntry getSimilarCountLeaderBoard() {
+        return similarCountLeaderBoard;
+    }
 
-	public void refresh() {
-		similarCountLeaderBoard.refresh();
-		likeLeaderBoard.refresh();
-		similarLikeSumLeaderboard.refresh();
-	}
+    public void refresh() {
+        similarCountLeaderBoard.refresh();
+        likeLeaderBoard.refresh();
+        similarLikeSumLeaderboard.refresh();
+    }
 
-	public static class LeaderBoardEntry {
-		private final Comparator<? super Reply> comparator;
-		private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
-		List<Reply> allReplies;
-		List<Reply> repliesInOneWeek;
-		List<Reply> repliesInThreeDays;
-		private Predicate<Reply> allRepliesFilter;
-		private Predicate<Reply> repliesInOneWeekFilter;
-		private Predicate<Reply> repliesInThreeDaysFilter;
+    public static class LeaderBoardEntry {
+        private final Comparator<? super Reply> comparator;
+        private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+        List<Reply> allReplies;
+        List<Reply> repliesInOneWeek;
+        List<Reply> repliesInThreeDays;
+        private Predicate<Reply> allRepliesFilter;
+        private Predicate<Reply> repliesInOneWeekFilter;
+        private Predicate<Reply> repliesInThreeDaysFilter;
 
-		private LeaderBoardEntry(final Comparator<Reply> comparator) {
-			this.comparator = comparator;
-		}
+        private LeaderBoardEntry(final Comparator<Reply> comparator) {
+            this.comparator = comparator;
+        }
 
 
-		public void setAllRepliesFilter(final Predicate<Reply> allRepliesFilter) {
-			this.allRepliesFilter = allRepliesFilter;
-		}
+        public void setAllRepliesFilter(final Predicate<Reply> allRepliesFilter) {
+            this.allRepliesFilter = allRepliesFilter;
+        }
 
-		public void setRepliesInThreeDaysFilter(final Predicate<Reply> repliesInThreeDaysFilter) {
-			this.repliesInThreeDaysFilter = repliesInThreeDaysFilter;
-		}
+        public void setRepliesInThreeDaysFilter(final Predicate<Reply> repliesInThreeDaysFilter) {
+            this.repliesInThreeDaysFilter = repliesInThreeDaysFilter;
+        }
 
-		public void setRepliesInOneWeekFilter(final Predicate<Reply> repliesInOneWeekFilter) {
-			this.repliesInOneWeekFilter = repliesInOneWeekFilter;
-		}
+        public void setRepliesInOneWeekFilter(final Predicate<Reply> repliesInOneWeekFilter) {
+            this.repliesInOneWeekFilter = repliesInOneWeekFilter;
+        }
 
-		void refresh() {
-			ComparisonDatabase.getInstance().readLock();
-			rwLock.writeLock().lock();
-			try {
+        void refresh() {
+            ComparisonDatabase.getInstance().readLock();
+            rwLock.writeLock().lock();
+            try {
 
-				allReplies = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
-						filter(allRepliesFilter).sorted(comparator).collect(Collectors.toList());
+                allReplies = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
+                        filter(allRepliesFilter).sorted(comparator).collect(Collectors.toList());
 
-				Calendar c = Calendar.getInstance();
-				Date maxTime = new Date(ComparisonDatabase.getInstance().getMaxTime() * 1000L);
-				c.setTime(maxTime);
-				c.add(Calendar.DATE, -7);
-				Predicate<Reply> timePredicate = r -> r.getCtime() * 1000L >= c.getTime().getTime();
-				repliesInOneWeek = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
-						filter(repliesInOneWeekFilter.and(timePredicate)).sorted(comparator).collect(Collectors.toList());
+                Calendar c = Calendar.getInstance();
+                Date maxTime = new Date(ComparisonDatabase.getInstance().getMaxTime() * 1000L);
+                c.setTime(maxTime);
+                c.add(Calendar.DATE, -7);
+                Predicate<Reply> timePredicate = r -> r.getCtime() * 1000L >= c.getTime().getTime();
+                repliesInOneWeek = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
+                        filter(repliesInOneWeekFilter.and(timePredicate)).sorted(comparator).collect(Collectors.toList());
 
-				c.setTime(maxTime);
-				c.add(Calendar.DATE, -3);
-				timePredicate = r -> r.getCtime() * 1000L >= c.getTime().getTime();
-				repliesInThreeDays = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
-						filter(repliesInThreeDaysFilter.and(timePredicate)).sorted(comparator).collect(Collectors.toList());
-			} finally {
-				ComparisonDatabase.getInstance().readUnLock();
-				rwLock.writeLock().unlock();
-			}
-		}
+                c.setTime(maxTime);
+                c.add(Calendar.DATE, -3);
+                timePredicate = r -> r.getCtime() * 1000L >= c.getTime().getTime();
+                repliesInThreeDays = ComparisonDatabase.getInstance().getReplyMap().values().stream(). //
+                        filter(repliesInThreeDaysFilter.and(timePredicate)).sorted(comparator).collect(Collectors.toList());
+            } finally {
+                ComparisonDatabase.getInstance().readUnLock();
+                rwLock.writeLock().unlock();
+            }
+        }
 
-		public RankingResultVo query(Predicate<Reply> filter, TimeRangeEnum timeRange, int pageSize, int pageNum) {
-			ComparisonDatabase.getInstance().readLock();
-			rwLock.readLock().lock();
-			try {
-				if (pageSize == 0 || pageNum < 1) {
-					return new RankingResultVo();
-				}
+        public RankingResultVo query(Predicate<Reply> filter, TimeRangeEnum timeRange, int pageSize, int pageNum) {
+            ComparisonDatabase.getInstance().readLock();
+            rwLock.readLock().lock();
+            try {
+                if (pageSize == 0 || pageNum < 1) {
+                    return new RankingResultVo();
+                }
 
-				// set time filter
-				List<Reply> targetReplySource = allReplies;
-				switch (timeRange) {
-				case ONE_WEEK:
-					targetReplySource = repliesInOneWeek;
-					break;
-				case THREE_DAYS:
-					targetReplySource = repliesInThreeDays;
-					break;
-				default:
-					break;
-				}
+                // set time filter
+                List<Reply> targetReplySource = allReplies;
+                switch (timeRange) {
+                    case ONE_WEEK:
+                        targetReplySource = repliesInOneWeek;
+                        break;
+                    case THREE_DAYS:
+                        targetReplySource = repliesInThreeDays;
+                        break;
+                    default:
+                        break;
+                }
 
-				List<Reply> result = targetReplySource.stream().filter(filter).collect(Collectors.toList());
+                List<Reply> result = targetReplySource.stream().filter(filter).collect(Collectors.toList());
 
-				int minTime = ComparisonDatabase.getInstance().getMinTime();
-				int maxTime = ComparisonDatabase.getInstance().getMaxTime();
+                int minTime = ComparisonDatabase.getInstance().getMinTime();
+                int maxTime = ComparisonDatabase.getInstance().getMaxTime();
 
-				return new RankingResultVo(page(result, pageSize, pageNum), result.size(), minTime,
-						maxTime);
-			} finally {
-				ComparisonDatabase.getInstance().readUnLock();
-				rwLock.readLock().unlock();
-			}
-		}
-	}
+                return new RankingResultVo(page(result, pageSize, pageNum), result.size(), minTime,
+                        maxTime);
+            } finally {
+                ComparisonDatabase.getInstance().readUnLock();
+                rwLock.readLock().unlock();
+            }
+        }
+
+
+        public List<Reply> queryLoveLetters(QueryRandomLoveLetterParam param) {
+            // 先筛出所有符合要求的小作文
+            Stream<Reply> stream = allReplies
+                    .stream()
+                    .filter(r -> r.isLoveLetter(param.getLikeNum(), param.getLength()));
+            // 如果有指定角色，再筛出指定角色小作文
+            if (param.getRole() != null) {
+                stream = stream.filter(r -> r.isSpecRoleLoveLetter(param.getRole(), 3));
+            }
+            // 剩下所有合法小作文
+            List<Reply> legalLoveLetters = stream.collect(Collectors.toList());
+            return RandomUtil.sample(legalLoveLetters, param.getLimit());
+        }
+    }
 }

--- a/src/main/java/asia/asoulcnki/api/common/util/RandomUtil.java
+++ b/src/main/java/asia/asoulcnki/api/common/util/RandomUtil.java
@@ -1,0 +1,29 @@
+package asia.asoulcnki.api.common.util;
+
+import java.util.*;
+
+public class RandomUtil {
+    public static <T> T choice(List<T> list) {
+        Random random = new Random();
+        int n = random.nextInt(list.size());
+        return list.get(n);
+    }
+
+    public static <T> List<T> sample(List<T> list, int num) {
+        if (list.size() < num) {
+            return list;
+        }
+        Random random = new Random();
+        Map<Integer, T> map = new HashMap<>();
+        while (map.size() < num) {
+            int n = random.nextInt(list.size());
+            if (!map.containsKey(n)) {
+                T data = list.get(n);
+                map.put(n, data);
+            }
+        }
+        List<T> ret = new ArrayList<>(map.values());
+        Collections.shuffle(ret);
+        return ret;
+    }
+}

--- a/src/main/java/asia/asoulcnki/api/controller/LoveLetterController.java
+++ b/src/main/java/asia/asoulcnki/api/controller/LoveLetterController.java
@@ -1,0 +1,27 @@
+package asia.asoulcnki.api.controller;
+
+import asia.asoulcnki.api.common.response.ApiResult;
+import asia.asoulcnki.api.persistence.entity.Reply;
+import asia.asoulcnki.api.persistence.param.QueryRandomLoveLetterParam;
+import asia.asoulcnki.api.service.ILoveLetterService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Validated
+public class LoveLetterController {
+    @Autowired
+    private ILoveLetterService loveLetterService;
+
+    @GetMapping("/loveletter/random")
+    @ResponseBody
+    public ApiResult<List<Reply>> queryLoveLetter(QueryRandomLoveLetterParam param) {
+        return ApiResult.ok(loveLetterService.queryLoveLetter(param));
+    }
+
+}

--- a/src/main/java/asia/asoulcnki/api/enums/ASoulRoleEnum.java
+++ b/src/main/java/asia/asoulcnki/api/enums/ASoulRoleEnum.java
@@ -1,0 +1,22 @@
+package asia.asoulcnki.api.enums;
+
+import com.baomidou.mybatisplus.annotation.EnumValue;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ASoulRoleEnum {
+    AVA(0, "向晚"),
+    BELLA(1, "贝拉"),
+    CAROL(2, "珈乐"),
+    DIANA(3, "嘉然"),
+    EILEEN(4, "乃琳");
+
+    @EnumValue
+    private int code;
+
+    @JsonValue
+    private String name;
+}

--- a/src/main/java/asia/asoulcnki/api/persistence/entity/Reply.java
+++ b/src/main/java/asia/asoulcnki/api/persistence/entity/Reply.java
@@ -1,5 +1,6 @@
 package asia.asoulcnki.api.persistence.entity;
 
+import asia.asoulcnki.api.enums.ASoulRoleEnum;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -8,59 +9,112 @@ import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 @ToString
 public class Reply implements Serializable {
-	private static final long serialVersionUID = 6554064566476229771L;
+    private static final long serialVersionUID = 6554064566476229771L;
 
-	@TableId(value = "rpid")
-	@JsonProperty("rpid")
-	@JsonSerialize(using = ToStringSerializer.class)
-	private Long rpid;
+    @TableId(value = "rpid")
+    @JsonProperty("rpid")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long rpid;
 
-	@JsonProperty("type_id")
-	private int typeId;
+    @JsonProperty("type_id")
+    private int typeId;
 
-	@JsonProperty("dynamic_id")
-	@JsonSerialize(using = ToStringSerializer.class)
-	private long dynamicId;
+    @JsonProperty("dynamic_id")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private long dynamicId;
 
-	@JsonProperty("mid")
-	private int mid;
+    @JsonProperty("mid")
+    private int mid;
 
     @JsonProperty("uid")
     private int uid;
 
-	@JsonProperty("oid")
-	@JsonSerialize(using = ToStringSerializer.class)
-	private long oid;
+    @JsonProperty("oid")
+    @JsonSerialize(using = ToStringSerializer.class)
+    private long oid;
 
-	@JsonProperty("ctime")
-	private int ctime;
+    @JsonProperty("ctime")
+    private int ctime;
 
-	@JsonProperty("m_name")
-	private String mName;
+    @JsonProperty("m_name")
+    private String mName;
 
-	@JsonProperty("content")
-	private String content;
+    @JsonProperty("content")
+    private String content;
 
-	@JsonProperty("like_num")
-	private int likeNum;
+    @JsonProperty("like_num")
+    private int likeNum;
 
-	@JsonProperty("origin_rpid")
-	@TableField(exist = false)
-	@JsonSerialize(using = ToStringSerializer.class)
-	private Long originRpid = -1L;
+    @JsonProperty("origin_rpid")
+    @TableField(exist = false)
+    @JsonSerialize(using = ToStringSerializer.class)
+    private Long originRpid = -1L;
 
-	@TableField(exist = false)
-	@JsonProperty("similar_count")
-	private Integer similarCount = 0;
+    @TableField(exist = false)
+    @JsonProperty("similar_count")
+    private Integer similarCount = 0;
 
-	@TableField(exist = false)
-	@JsonProperty("similar_like_sum")
-	private Integer similarLikeSum = 0;
+    @TableField(exist = false)
+    @JsonProperty("similar_like_sum")
+    private Integer similarLikeSum = 0;
+
+    /**
+     * 得到小作文里某角色出现次数
+     *
+     * @param roleEnum
+     * @return
+     */
+    public int getLetterRoleRepeatNum(ASoulRoleEnum roleEnum) {
+        if (StringUtils.isEmpty(content)) {
+            return 0;
+        }
+        if (roleEnum == null) {
+            return 0;
+        }
+        return content.split(roleEnum.getName()).length - 1;
+    }
+
+    /**
+     * 当点赞大于指定数，字数大于指定数时，我们认为这是一篇小作文
+     *
+     * @return
+     */
+    public boolean isLoveLetter(int likeNum, int length) {
+        // 基础条件
+        boolean baseCond = this.likeNum > likeNum && this.content.length() > length;
+        // 附加条件，如向晚的小作文里经常有 "向晚不是"，"阿八" 等关键字，一般是撕逼，要排除。如珈乐也有请假等大量干扰选项
+        // TODO: 优化一下排除算法，但这需要更多数据，同时要考虑到性能
+        // TODO: 一个想法：单独靠算法排除掉干扰选项是很难做完善的，一般来说，au们看到小作文才会去查重。如果在查重时，
+        //  将匹配的小作文查重次数 +1，之后小作文就从如 查重次数 > 10 的小作文里随机挑选，这样可以保证小作文是比较准确的，而不是骂战留言之类的
+        List<String> keywords = Arrays.asList("阿八", "小粒", "请假", "切片", "道歉", "出问题", "解释", "挖掘机", "复盘", "节奏", "运营", "路人", "贵物", "笑嘻");
+        boolean extraCond = keywords.stream().noneMatch(k -> content.contains(k));
+        return baseCond && extraCond;
+    }
+
+    public boolean isLoveLetter() {
+        return isLoveLetter(50, 30);
+    }
+
+    /**
+     * 是否是某个特定的人的小作文？
+     *
+     * @param roleEnum
+     * @param repeatNum
+     * @return
+     */
+    public boolean isSpecRoleLoveLetter(ASoulRoleEnum roleEnum, int repeatNum) {
+        // TODO: 是否某个人的小作文算法应该更详细，如有些小作文只出现霓虹甜心和红色高跟鞋而不出现珈乐，待优化
+        return getLetterRoleRepeatNum(roleEnum) > repeatNum;
+    }
+
 }

--- a/src/main/java/asia/asoulcnki/api/persistence/param/QueryRandomLoveLetterParam.java
+++ b/src/main/java/asia/asoulcnki/api/persistence/param/QueryRandomLoveLetterParam.java
@@ -1,0 +1,16 @@
+package asia.asoulcnki.api.persistence.param;
+
+import asia.asoulcnki.api.enums.ASoulRoleEnum;
+import lombok.Data;
+
+@Data
+public class QueryRandomLoveLetterParam {
+    // 谁的小作文，null 表示所有人，前端传 AVA, DIANA 等枚举名
+    private ASoulRoleEnum role;
+    // 随机几篇小作文
+    private int limit = 10;
+    // 点赞大于多少
+    private int likeNum = 50;
+    // 字数大于多少
+    private int length = 30;
+}

--- a/src/main/java/asia/asoulcnki/api/service/ILoveLetterService.java
+++ b/src/main/java/asia/asoulcnki/api/service/ILoveLetterService.java
@@ -1,0 +1,10 @@
+package asia.asoulcnki.api.service;
+
+import asia.asoulcnki.api.persistence.entity.Reply;
+import asia.asoulcnki.api.persistence.param.QueryRandomLoveLetterParam;
+
+import java.util.List;
+
+public interface ILoveLetterService {
+    List<Reply> queryLoveLetter(QueryRandomLoveLetterParam param);
+}

--- a/src/main/java/asia/asoulcnki/api/service/impl/ILoveLetterServiceImpl.java
+++ b/src/main/java/asia/asoulcnki/api/service/impl/ILoveLetterServiceImpl.java
@@ -1,0 +1,20 @@
+package asia.asoulcnki.api.service.impl;
+
+import asia.asoulcnki.api.common.duplicationcheck.LeaderBoard;
+import asia.asoulcnki.api.persistence.entity.Reply;
+import asia.asoulcnki.api.persistence.param.QueryRandomLoveLetterParam;
+import asia.asoulcnki.api.service.ILoveLetterService;
+import org.springframework.stereotype.Service;
+import asia.asoulcnki.api.common.duplicationcheck.LeaderBoard.LeaderBoardEntry;
+
+
+import java.util.List;
+
+@Service
+public class ILoveLetterServiceImpl implements ILoveLetterService {
+    @Override
+    public List<Reply> queryLoveLetter(QueryRandomLoveLetterParam param){
+        LeaderBoardEntry leaderBoard = LeaderBoard.getInstance().getSimilarCountLeaderBoard();
+        return leaderBoard.queryLoveLetters(param);
+    }
+}


### PR DESCRIPTION
最近太忙啦 鸽了很久 不好意思

初版功能，文档还没加，先提个 pr

一个想法：单独靠算法排除掉干扰选项是很难做完善的，一般来说，au们看到小作文才会去查重。如果在查重时，将匹配的小作文查重次数 +1，之后小作文就从如 查重次数 > 10 的小作文里随机挑选，这样可以保证小作文是比较准确的，而不是骂战留言之类的，性能也是非常快的

延伸：统计了查重次数后，枝江作文展也可以以此方法筛选作文，现有作文展有一些干扰，比如晚晚请假等不是作文的也被展示出来。强烈建议增加查重次数统计，帮助筛选优秀小作文